### PR TITLE
feat: create show & dismiss method for loading view (indicator) ✨

### DIFF
--- a/GitHubFollowers/Extenions/UIViewController+Extension.swift
+++ b/GitHubFollowers/Extenions/UIViewController+Extension.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+fileprivate var containerView: UIView!
+
 extension UIViewController {
     func presentGFAlertOnMainThread(title: String , message:String , buttonTitle: String){
         DispatchQueue.main.async {
@@ -14,6 +16,38 @@ extension UIViewController {
             alertVC.modalPresentationStyle = .overFullScreen
             alertVC.modalTransitionStyle = .crossDissolve
             self.present(alertVC, animated: true)
+        }
+    }
+    
+    func showLoadingView() {
+        containerView = UIView(frame: view.bounds)
+        view.addSubview(containerView)
+        
+        containerView.backgroundColor = .systemBackground
+        containerView.alpha = 0
+        
+        UIView.animate(withDuration: 0.25) {
+            containerView.alpha = 0.8
+        }
+        
+        let activityIndicator = UIActivityIndicatorView(style: .large)
+        containerView.addSubview(activityIndicator)
+        
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+        
+        activityIndicator.startAnimating()
+    }
+    
+    
+    func dismissLoadingView()  {
+        DispatchQueue.main.async {
+            containerView.removeFromSuperview()
+            containerView = nil
         }
     }
 }

--- a/GitHubFollowers/Screens/FollowerListViewController.swift
+++ b/GitHubFollowers/Screens/FollowerListViewController.swift
@@ -49,8 +49,10 @@ class FollowerListViewController: UIViewController {
     
     
     func getFollowers(for username:String , page:Int) {
+        showLoadingView()
         NetworkManager.shared.getFollowers(for: username, page: page) { [weak self] result in
             guard let self = self else {return}
+            self.dismissLoadingView()
             switch result {
             case .success(let followers):
                 if followers.count < 100 {self.hasMoreFollowers = false}


### PR DESCRIPTION
 - add 2 method to an extension for a UIViewController `showLoadingView` and `dismissLoadingView` for loading view (indication) 
 
- calling `showLoadingView` before the getting follower result method 

- calling `dismissLoadingView` in the closure after unwrapping  the url